### PR TITLE
Add quantization benchmarking scripts for Kyutai STT and TTS

### DIFF
--- a/README_QUANT_BENCH.md
+++ b/README_QUANT_BENCH.md
@@ -1,0 +1,71 @@
+# Kyutai Quantization Benchmarks
+
+This toolkit bundles the benchmarking helpers that were previously outlined in
+chat. It covers both Kyutai's speech-to-text (STT) and text-to-speech (TTS)
+paths with weight-only quantization and simple performance logging.
+
+## Contents
+
+| File | Purpose |
+| --- | --- |
+| `stt_bnb_quant_bench.py` | Loads the Transformers STT model with bitsandbytes quantization (4-bit or 8-bit) on CUDA and reports load time, VRAM peaks, and per-file RTF. |
+| `tts_mlx_quant_bench.py` | Wraps Kyutai's `scripts/tts_mlx.py` with the MLX quantization flags and measures wall time, audio duration, RTF, and peak RSS on Apple Silicon. |
+| `setup_quant_env.sh` | Convenience installer for the Python dependencies needed by the two scripts. |
+
+## Quick start
+
+1. Install dependencies:
+   ```bash
+   ./setup_quant_env.sh
+   ```
+
+2. Run the CUDA STT benchmark:
+   ```bash
+   python stt_bnb_quant_bench.py --bits 4 path/to/audio.wav
+   ```
+
+3. Run the MLX TTS benchmark (from the repository root so the script path resolves):
+   ```bash
+   python tts_mlx_quant_bench.py --quantize 8 --text "Hello, Kyutai" --outfile out.wav
+   ```
+
+### STT options
+
+The STT script accepts multiple audio files and writes optional CSV summaries:
+
+```bash
+python stt_bnb_quant_bench.py \
+  --bits 4 \
+  --csv results.csv \
+  audio/*.wav
+```
+
+Generation parameters such as `--max-new-tokens`, `--temperature`, and
+`--beam-size` are forwarded to `model.generate` for experimentation. RTF is
+reported for both the pure generation loop and the overall preprocessing +
+inference time.
+
+### TTS options
+
+The MLX wrapper proxies convenient arguments to Kyutai's script:
+
+```bash
+python tts_mlx_quant_bench.py \
+  --script scripts/tts_mlx.py \
+  --quantize 4 \
+  --text "Make it punchy." \
+  --outfile quantized.wav \
+  --voice ljspeech
+```
+
+Additional flags can be passed after `--extra-args`. The script captures the
+child process' peak RSS and prints any stdout/stderr emitted by the MLX helper
+for troubleshooting.
+
+## Notes
+
+* bitsandbytes wheels are available on Linux with CUDA GPUs. macOS users should
+  prefer the MLX path instead.
+* Audio is resampled to 24 kHz to match Kyutai's pretrained STT expectations.
+* The benchmark output is intentionally JSON-formatted to make it easy to pipe
+  into other tooling for automation.

--- a/setup_quant_env.sh
+++ b/setup_quant_env.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Set up Python environments for Kyutai quantization demos.
+set -euo pipefail
+
+python_bin="${PYTHON:-python3}"
+
+if ! command -v "$python_bin" >/dev/null 2>&1; then
+  echo "Python executable '$python_bin' not found." >&2
+  exit 1
+fi
+
+# CUDA + bitsandbytes requirements for STT benchmarking
+"$python_bin" -m pip install -U \
+  "transformers>=4.56.0" \
+  accelerate \
+  "bitsandbytes>=0.43.0" \
+  soundfile \
+  scipy \
+  psutil
+
+# MLX TTS requirements
+"$python_bin" -m pip install -U \
+  "moshi-mlx>=0.2.9" \
+  sentencepiece \
+  soundfile \
+  sounddevice \
+  psutil
+
+echo "Dependencies installed. Use stt_bnb_quant_bench.py for CUDA STT and tts_mlx_quant_bench.py for MLX TTS." 

--- a/stt_bnb_quant_bench.py
+++ b/stt_bnb_quant_bench.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+"""Benchmark Kyutai STT models with bitsandbytes weight-only quantization.
+
+This script loads the Transformers variant of the Kyutai STT model using
+bitsandbytes 4-bit or 8-bit weight-only quantization and records
+real-time factor (RTF) and GPU memory usage for both the loading phase and
+per-file inference runs.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+import numpy as np
+import soundfile as sf
+import torch
+from scipy import signal
+from transformers import (
+    BitsAndBytesConfig,
+    KyutaiSpeechToTextForConditionalGeneration,
+    KyutaiSpeechToTextProcessor,
+)
+
+
+TARGET_SAMPLE_RATE = 24_000
+
+
+def _format_bytes(num_bytes: int) -> str:
+    if num_bytes <= 0:
+        return "0 B"
+    units = ["B", "KiB", "MiB", "GiB", "TiB"]
+    exponent = min(int(math.log(num_bytes, 1024)), len(units) - 1)
+    value = num_bytes / (1024**exponent)
+    return f"{value:.2f} {units[exponent]}"
+
+
+@dataclass
+class LoadMetrics:
+    load_time_s: float
+    peak_alloc_bytes: int
+    peak_reserved_bytes: int
+
+    def to_print_dict(self) -> dict[str, str]:
+        return {
+            "load_time_s": f"{self.load_time_s:.2f}",
+            "peak_alloc": _format_bytes(self.peak_alloc_bytes),
+            "peak_reserved": _format_bytes(self.peak_reserved_bytes),
+        }
+
+
+@dataclass
+class InferenceMetrics:
+    audio_path: str
+    audio_sec: float
+    generation_time_s: float
+    total_time_s: float
+    rtf_generation: float
+    rtf_total: float
+    peak_alloc_bytes: int
+    peak_reserved_bytes: int
+    transcript: str
+
+    def to_print_dict(self) -> dict[str, str]:
+        return {
+            "audio": self.audio_path,
+            "audio_sec": f"{self.audio_sec:.2f}",
+            "gen_time_s": f"{self.generation_time_s:.2f}",
+            "total_time_s": f"{self.total_time_s:.2f}",
+            "rtf_gen": f"{self.rtf_generation:.2f}",
+            "rtf_total": f"{self.rtf_total:.2f}",
+            "peak_alloc": _format_bytes(self.peak_alloc_bytes),
+            "peak_reserved": _format_bytes(self.peak_reserved_bytes),
+        }
+
+
+class CudaMemoryMonitor:
+    def __init__(self) -> None:
+        if not torch.cuda.is_available():
+            raise RuntimeError("CUDA is required for this benchmark.")
+
+    def __enter__(self):
+        torch.cuda.reset_peak_memory_stats()
+        torch.cuda.empty_cache()
+        self.start_alloc = torch.cuda.memory_allocated()
+        self.start_reserved = torch.cuda.memory_reserved()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+    @property
+    def peak(self) -> tuple[int, int]:
+        return (
+            torch.cuda.max_memory_allocated(),
+            torch.cuda.max_memory_reserved(),
+        )
+
+
+@dataclass
+class Config:
+    model_id: str
+    bits: int
+    dtype: Optional[str]
+    device_map: str
+    max_new_tokens: Optional[int]
+    temperature: float
+    top_p: float
+    beam_size: int
+    no_repeat_ngram_size: int
+
+
+@dataclass
+class Arguments:
+    audio_files: List[Path]
+    csv_out: Optional[Path]
+    config: Config
+
+
+class AudioLoader:
+    def __init__(self, target_sample_rate: int = TARGET_SAMPLE_RATE) -> None:
+        self.target_sample_rate = target_sample_rate
+
+    def load(self, path: Path) -> tuple[np.ndarray, float]:
+        data, sample_rate = sf.read(path)
+        if data.ndim == 2:
+            data = np.mean(data, axis=1)
+        if sample_rate != self.target_sample_rate:
+            data = self._resample(data, sample_rate)
+        duration = float(len(data) / self.target_sample_rate)
+        return data.astype(np.float32), duration
+
+    def _resample(self, data: np.ndarray, sample_rate: int) -> np.ndarray:
+        gcd = math.gcd(sample_rate, self.target_sample_rate)
+        up = self.target_sample_rate // gcd
+        down = sample_rate // gcd
+        return signal.resample_poly(data, up, down)
+
+
+def parse_args() -> Arguments:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "audio_files",
+        nargs="+",
+        type=Path,
+        help="Audio files to transcribe.",
+    )
+    parser.add_argument(
+        "--model-id",
+        default="kyutai/stt-2.6b-en-trfs",
+        help="Transformers model identifier.",
+    )
+    parser.add_argument(
+        "--bits",
+        type=int,
+        choices=(4, 8),
+        default=4,
+        help="Quantization precision in bits (weight-only).",
+    )
+    parser.add_argument(
+        "--dtype",
+        default=None,
+        help="Override compute dtype (torch dtype string).",
+    )
+    parser.add_argument(
+        "--device-map",
+        default="auto",
+        help="Device map passed to from_pretrained.",
+    )
+    parser.add_argument(
+        "--max-new-tokens",
+        type=int,
+        default=None,
+        help="Optional maximum number of tokens to generate.",
+    )
+    parser.add_argument(
+        "--temperature",
+        type=float,
+        default=0.0,
+        help="Sampling temperature.",
+    )
+    parser.add_argument(
+        "--top-p",
+        type=float,
+        default=1.0,
+        help="Top-p nucleus sampling parameter.",
+    )
+    parser.add_argument(
+        "--beam-size",
+        type=int,
+        default=1,
+        help="Beam search width.",
+    )
+    parser.add_argument(
+        "--no-repeat-ngram-size",
+        type=int,
+        default=0,
+        help="Disallow repeating ngrams of this size if > 0.",
+    )
+    parser.add_argument(
+        "--csv",
+        type=Path,
+        default=None,
+        help="Optional CSV output path for metrics.",
+    )
+    args = parser.parse_args()
+
+    config = Config(
+        model_id=args.model_id,
+        bits=args.bits,
+        dtype=args.dtype,
+        device_map=args.device_map,
+        max_new_tokens=args.max_new_tokens,
+        temperature=args.temperature,
+        top_p=args.top_p,
+        beam_size=args.beam_size,
+        no_repeat_ngram_size=args.no_repeat_ngram_size,
+    )
+    return Arguments(audio_files=args.audio_files, csv_out=args.csv, config=config)
+
+
+def build_bnb_config(bits: int, dtype: Optional[str]) -> BitsAndBytesConfig:
+    if bits == 4:
+        return BitsAndBytesConfig(
+            load_in_4bit=True,
+            bnb_4bit_quant_type="nf4",
+            bnb_4bit_use_double_quant=True,
+            bnb_4bit_compute_dtype=getattr(torch, dtype) if dtype else torch.bfloat16,
+        )
+    if bits == 8:
+        return BitsAndBytesConfig(
+            load_in_8bit=True,
+            llm_int8_enable_fp32_cpu_offload=False,
+        )
+    raise ValueError("bits must be 4 or 8")
+
+
+def load_model(config: Config) -> tuple[
+    KyutaiSpeechToTextProcessor, KyutaiSpeechToTextForConditionalGeneration, LoadMetrics
+]:
+    bnb_config = build_bnb_config(config.bits, config.dtype)
+    dtype = getattr(torch, config.dtype) if config.dtype else "auto"
+
+    processor = KyutaiSpeechToTextProcessor.from_pretrained(config.model_id)
+
+    with CudaMemoryMonitor() as monitor:
+        start = time.perf_counter()
+        model = KyutaiSpeechToTextForConditionalGeneration.from_pretrained(
+            config.model_id,
+            quantization_config=bnb_config,
+            torch_dtype=dtype,
+            device_map=config.device_map,
+        )
+        torch.cuda.synchronize()
+        load_time = time.perf_counter() - start
+        peak_alloc, peak_reserved = monitor.peak
+
+    metrics = LoadMetrics(load_time_s=load_time, peak_alloc_bytes=peak_alloc, peak_reserved_bytes=peak_reserved)
+    return processor, model, metrics
+
+
+def transcribe(
+    audio_loader: AudioLoader,
+    processor: KyutaiSpeechToTextProcessor,
+    model: KyutaiSpeechToTextForConditionalGeneration,
+    config: Config,
+    audio_paths: Iterable[Path],
+) -> List[InferenceMetrics]:
+    results: List[InferenceMetrics] = []
+
+    generation_kwargs = {
+        "temperature": config.temperature,
+        "top_p": config.top_p,
+        "num_beams": config.beam_size,
+    }
+    if config.max_new_tokens is not None:
+        generation_kwargs["max_new_tokens"] = config.max_new_tokens
+    if config.no_repeat_ngram_size > 0:
+        generation_kwargs["no_repeat_ngram_size"] = config.no_repeat_ngram_size
+
+    for path in audio_paths:
+        audio, duration = audio_loader.load(path)
+        inputs = processor(audio, sampling_rate=TARGET_SAMPLE_RATE, return_tensors="pt")
+        inputs = {k: v.to(model.device) for k, v in inputs.items()}
+
+        torch.cuda.synchronize()
+        preprocess_done = time.perf_counter()
+        with CudaMemoryMonitor() as monitor:
+            gen_start = time.perf_counter()
+            with torch.inference_mode():
+                generated = model.generate(**inputs, **generation_kwargs)
+            torch.cuda.synchronize()
+            gen_time = time.perf_counter() - gen_start
+            peak_alloc, peak_reserved = monitor.peak
+        total_time = time.perf_counter() - preprocess_done
+
+        transcript = processor.batch_decode(generated, skip_special_tokens=True)[0]
+        rtf_gen = gen_time / duration if duration > 0 else float("inf")
+        rtf_total = total_time / duration if duration > 0 else float("inf")
+
+        metrics = InferenceMetrics(
+            audio_path=str(path),
+            audio_sec=duration,
+            generation_time_s=gen_time,
+            total_time_s=total_time,
+            rtf_generation=rtf_gen,
+            rtf_total=rtf_total,
+            peak_alloc_bytes=peak_alloc,
+            peak_reserved_bytes=peak_reserved,
+            transcript=transcript,
+        )
+        results.append(metrics)
+    return results
+
+
+def write_csv(path: Path, load_metrics: LoadMetrics, inference_metrics: List[InferenceMetrics]) -> None:
+    fieldnames = [
+        "audio",
+        "audio_sec",
+        "generation_time_s",
+        "total_time_s",
+        "rtf_generation",
+        "rtf_total",
+        "peak_alloc_bytes",
+        "peak_reserved_bytes",
+        "transcript",
+    ]
+    with path.open("w", newline="") as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=["phase", *fieldnames])
+        writer.writeheader()
+        writer.writerow(
+            {
+                "phase": "load",
+                "audio": "model_load",
+                "audio_sec": "",
+                "generation_time_s": load_metrics.load_time_s,
+                "total_time_s": load_metrics.load_time_s,
+                "rtf_generation": "",
+                "rtf_total": "",
+                "peak_alloc_bytes": load_metrics.peak_alloc_bytes,
+                "peak_reserved_bytes": load_metrics.peak_reserved_bytes,
+                "transcript": json.dumps(load_metrics.to_print_dict()),
+            }
+        )
+        for metrics in inference_metrics:
+            writer.writerow(
+                {
+                    "phase": "inference",
+                    "audio": metrics.audio_path,
+                    "audio_sec": metrics.audio_sec,
+                    "generation_time_s": metrics.generation_time_s,
+                    "total_time_s": metrics.total_time_s,
+                    "rtf_generation": metrics.rtf_generation,
+                    "rtf_total": metrics.rtf_total,
+                    "peak_alloc_bytes": metrics.peak_alloc_bytes,
+                    "peak_reserved_bytes": metrics.peak_reserved_bytes,
+                    "transcript": metrics.transcript,
+                }
+            )
+
+
+def main() -> None:
+    args = parse_args()
+    audio_loader = AudioLoader()
+
+    processor, model, load_metrics = load_model(args.config)
+    print("Model load metrics:")
+    print(json.dumps(load_metrics.to_print_dict(), indent=2))
+
+    inference_metrics = transcribe(audio_loader, processor, model, args.config, args.audio_files)
+
+    print("\nInference metrics:")
+    for metrics in inference_metrics:
+        data = metrics.to_print_dict()
+        print(json.dumps(data, indent=2))
+        print(f"Transcript: {metrics.transcript}\n")
+
+    if args.csv_out:
+        write_csv(args.csv_out, load_metrics, inference_metrics)
+        print(f"Metrics written to {args.csv_out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tts_mlx_quant_bench.py
+++ b/tts_mlx_quant_bench.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Wrapper around Kyutai's MLX TTS script with quantization benchmarking.
+
+The script launches ``scripts/tts_mlx.py`` in a subprocess, feeds text via
+stdin, and records wall-clock time, produced audio duration, and peak RSS
+(memory) of the child process. It is intended for Apple Silicon where MLX
+quantization is supported.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import List, Optional
+
+import psutil
+import soundfile as sf
+
+
+DEFAULT_SCRIPT = Path("scripts/tts_mlx.py")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--script", type=Path, default=DEFAULT_SCRIPT, help="Path to tts_mlx.py script.")
+    parser.add_argument("--quantize", type=int, choices=(4, 8), default=8, help="Quantization precision for MLX script.")
+    parser.add_argument("--text", required=True, help="Text to synthesize.")
+    parser.add_argument("--outfile", type=Path, required=True, help="Output WAV file path.")
+    parser.add_argument("--voice", type=str, default=None, help="Optional voice argument passed to the script.")
+    parser.add_argument("--speaker", type=str, default=None, help="Optional speaker argument passed to the script.")
+    parser.add_argument(
+        "--extra-args",
+        nargs=argparse.REMAINDER,
+        help="Additional arguments forwarded to the MLX script (e.g. --rate 1.1).",
+    )
+    return parser.parse_args()
+
+
+def ensure_script(script_path: Path) -> Path:
+    if not script_path.exists():
+        raise FileNotFoundError(f"Cannot find MLX script at {script_path}.")
+    return script_path
+
+
+def run_tts(
+    script_path: Path,
+    text: str,
+    outfile: Path,
+    quantize: int,
+    voice: Optional[str],
+    speaker: Optional[str],
+    extra_args: Optional[List[str]],
+) -> dict:
+    cmd = [sys.executable, str(script_path), "-", str(outfile), "--quantize", str(quantize)]
+    if voice:
+        cmd.extend(["--voice", voice])
+    if speaker:
+        cmd.extend(["--speaker", speaker])
+    if extra_args:
+        cmd.extend(extra_args)
+
+    process = subprocess.Popen(
+        cmd,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    ps_proc = psutil.Process(process.pid)
+    peak_rss = 0
+    stop_event = threading.Event()
+
+    def monitor_memory() -> None:
+        nonlocal peak_rss
+        while not stop_event.is_set():
+            try:
+                mem_info = ps_proc.memory_info()
+                peak_rss = max(peak_rss, mem_info.rss)
+            except psutil.Error:
+                break
+            time.sleep(0.05)
+
+    monitor_thread = threading.Thread(target=monitor_memory, daemon=True)
+    monitor_thread.start()
+
+    start = time.perf_counter()
+    try:
+        out, err = process.communicate(text + "\n")
+    finally:
+        stop_event.set()
+        monitor_thread.join(timeout=1.0)
+        end = time.perf_counter()
+
+    if process.returncode != 0:
+        raise RuntimeError(
+            f"TTS script failed with exit code {process.returncode}.\nSTDOUT:\n{out}\nSTDERR:\n{err}"
+        )
+
+    if not outfile.exists():
+        raise FileNotFoundError(f"Expected output file {outfile} was not created.")
+
+    audio, sample_rate = sf.read(outfile)
+    duration = audio.shape[0] / float(sample_rate)
+    if audio.ndim == 2:
+        duration = len(audio) / float(sample_rate)
+
+    wall_time = end - start
+    rtf = wall_time / duration if duration > 0 else float("inf")
+
+    return {
+        "wall_time_s": wall_time,
+        "audio_sec": duration,
+        "rtf": rtf,
+        "peak_rss_bytes": peak_rss,
+        "stdout": out,
+        "stderr": err,
+    }
+
+
+def main() -> None:
+    args = parse_args()
+    script_path = ensure_script(args.script)
+    outfile = args.outfile
+    outfile.parent.mkdir(parents=True, exist_ok=True)
+
+    metrics = run_tts(
+        script_path=script_path,
+        text=args.text,
+        outfile=outfile,
+        quantize=args.quantize,
+        voice=args.voice,
+        speaker=args.speaker,
+        extra_args=args.extra_args,
+    )
+
+    printable = {
+        "wall_time_s": f"{metrics['wall_time_s']:.2f}",
+        "audio_sec": f"{metrics['audio_sec']:.2f}",
+        "rtf": f"{metrics['rtf']:.2f}",
+        "peak_rss": f"{metrics['peak_rss_bytes'] / (1024 ** 2):.2f} MiB",
+    }
+    print(json.dumps(printable, indent=2))
+
+    if metrics["stdout"]:
+        print("\n--- Child STDOUT ---\n" + metrics["stdout"])
+    if metrics["stderr"]:
+        print("\n--- Child STDERR ---\n" + metrics["stderr"])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a CUDA-focused speech-to-text benchmark that quantizes Kyutai's Transformers model with bitsandbytes and reports load/inference metrics
- wrap the MLX text-to-speech demo with quantization, runtime, and memory tracking plus shared dependency setup docs
- document setup and usage for both flows via a quickstart README and installer script

## Testing
- python -m py_compile stt_bnb_quant_bench.py tts_mlx_quant_bench.py

------
https://chatgpt.com/codex/tasks/task_b_68d78eec32848320b1b8b46e4d3b9e70