### PR TITLE
docs: Review and document Caddy reverse proxy configuration

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,3 +1,25 @@
+# Moshi Server Reverse Proxy Configuration
+# See docs/REVERSE_PROXY_SETUP.md for details
+
 stt.fullen.dev {
+	# Better Auth server routes (if auth-server is running on port 3001)
+	# Uncomment the following block to enable auth server routing:
+	# handle /api/auth/* {
+	#     reverse_proxy localhost:3001
+	# }
+	# handle /health {
+	#     reverse_proxy localhost:3001
+	# }
+
+	# All other routes go to moshi-server
+	# This includes:
+	#   - /api/chat (WebSocket - ASR streaming)
+	#   - /api/asr (WebSocket - ASR streaming, dynamic path)
+	#   - /api/tts (POST - TTS)
+	#   - /api/tts_streaming (WebSocket - TTS streaming)
+	#   - /api/build_info (GET - build info)
+	#   - /api/modules_info (GET - modules info)
+	#   - /metrics (GET - Prometheus metrics)
+	#   - /* (Static files - client app)
 	reverse_proxy localhost:8080
 }

--- a/docs/REVERSE_PROXY_SETUP.md
+++ b/docs/REVERSE_PROXY_SETUP.md
@@ -9,6 +9,21 @@ This guide describes how to set up Caddy as a reverse proxy for the Moshi Server
 - Domain `stt.fullen.dev` DNS pointing to this server.
 - Ports 80 and 443 open on the firewall.
 
+## Routes Handled
+
+The following routes are proxied to moshi-server:
+
+| Route | Type | Description |
+|-------|------|-------------|
+| `/api/chat` | WebSocket | Real-time audio streaming (ASR) |
+| `/api/asr` | WebSocket | ASR streaming (dynamic path based on config) |
+| `/api/tts` | POST | Text-to-speech endpoint |
+| `/api/tts_streaming` | WebSocket | TTS streaming |
+| `/api/build_info` | GET | Server build information |
+| `/api/modules_info` | GET | Module information |
+| `/metrics` | GET | Prometheus metrics |
+| `/*` (fallback) | Static | Client application files |
+
 ## Configuration
 
 The Caddy configuration is located in the `Caddyfile` in the repository root:
@@ -16,6 +31,27 @@ The Caddy configuration is located in the `Caddyfile` in the repository root:
 ```caddy
 stt.fullen.dev {
     reverse_proxy localhost:8080
+}
+```
+
+### With Auth Server (Optional)
+
+If you're running the Better Auth server for user authentication:
+
+```caddy
+stt.fullen.dev {
+    # Auth server routes
+    handle /api/auth/* {
+        reverse_proxy localhost:3001
+    }
+    handle /health {
+        reverse_proxy localhost:3001
+    }
+
+    # Everything else goes to moshi-server
+    handle {
+        reverse_proxy localhost:8080
+    }
 }
 ```
 
@@ -28,7 +64,15 @@ stt.fullen.dev {
    moshi-server worker --config config.toml
    ```
 
-2. **Start Caddy**:
+2. **Start Auth Server (Optional)**:
+   If using Better Auth for authentication:
+
+   ```bash
+   cd moshi/auth-server
+   pnpm dev  # Runs on port 3001
+   ```
+
+3. **Start Caddy**:
    
    ```bash
    # Run in foreground (useful for testing)
@@ -39,3 +83,39 @@ stt.fullen.dev {
    ```
 
 Caddy will automatically provision and renew SSL certificates for `stt.fullen.dev` via Let's Encrypt.
+
+## Verification
+
+Test that all routes are working:
+
+```bash
+# Test static files (client app)
+curl -I https://stt.fullen.dev/
+
+# Test API endpoint
+curl https://stt.fullen.dev/api/build_info
+
+# Test metrics
+curl https://stt.fullen.dev/metrics
+
+# Test WebSocket (requires wscat or similar)
+# wscat -c wss://stt.fullen.dev/api/chat
+```
+
+## Troubleshooting
+
+### WebSocket Connection Issues
+
+Caddy automatically handles WebSocket upgrades. If you experience issues:
+
+1. Ensure moshi-server is running and accessible on port 8080
+2. Check Caddy logs: `sudo journalctl -u caddy -f`
+3. Verify the WebSocket endpoint responds: `curl -I -H "Upgrade: websocket" https://stt.fullen.dev/api/chat`
+
+### SSL Certificate Issues
+
+Caddy automatically provisions certificates. If there are issues:
+
+1. Ensure ports 80 and 443 are open
+2. Verify DNS is pointing to the correct IP
+3. Check Caddy logs for ACME errors


### PR DESCRIPTION
Fixes #25

## Summary

Reviewed and documented the Caddy reverse proxy configuration to ensure all necessary routes are properly handled.

## Analysis Results

The current configuration is **correct** for the deployment model where:
- moshi-server handles all routes including static file serving
- Authentication is handled via JWT tokens in WebSocket connections
- auth-server runs separately if needed

## Changes

### Caddyfile
- Added documentation comments explaining all proxied routes
- Added commented-out auth-server routing for future use
- Documented all endpoints:
  - WebSocket: `/api/chat`, `/api/asr`, `/api/tts_streaming`
  - API: `/api/build_info`, `/api/modules_info`, `/api/tts`
  - Metrics: `/metrics`
  - Static files: `/*` (fallback)

### docs/REVERSE_PROXY_SETUP.md
- Added routes table documenting all proxied endpoints
- Added optional auth-server configuration section
- Added verification commands for testing routes
- Added troubleshooting section for WebSocket and SSL issues

## Verification

```bash
$ caddy validate --config Caddyfile
Valid configuration
```

## Routes Summary

| Route | Type | Description |
|-------|------|-------------|
| `/api/chat` | WebSocket | Real-time audio streaming (ASR) |
| `/api/asr` | WebSocket | ASR streaming (dynamic path) |
| `/api/tts` | POST | Text-to-speech endpoint |
| `/api/tts_streaming` | WebSocket | TTS streaming |
| `/api/build_info` | GET | Server build information |
| `/api/modules_info` | GET | Module information |
| `/metrics` | GET | Prometheus metrics |
| `/*` (fallback) | Static | Client application files |