### PR TITLE
feat: add .env.example for moshi-server authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,29 @@
+# Moshi Server Environment Configuration
+# Copy this file to .env and fill in your values
+# Usage: source .env && moshi-server worker --config configs/config-stt-en-hf.toml
+
+# =============================================================================
+# AUTHENTICATION
+# =============================================================================
+
+# API Key Authentication (Legacy)
+# Comma-separated list of authorized API keys for the kyutai-api-key header
+# Generate a secure random key: openssl rand -hex 32
+MOSHI_API_KEY=your_api_key_here
+
+# Better Auth JWT Secret (Optional)
+# Required if using Better Auth for user authentication
+# Must match the secret configured in auth-server
+# BETTER_AUTH_SECRET=your_jwt_secret_here
+
+# =============================================================================
+# VRAM / GPU CONFIGURATION (Optional)
+# =============================================================================
+
+# Model size hint in billions of parameters (default: 7.0)
+# Used for VRAM estimation. Set to 2.6 for the 2.6B STT model.
+# MOSHI_MODEL_PARAMS_BILLIONS=2.6
+
+# VRAM per batch item estimate in MB (default: 400)
+# Adjust if you experience OOM errors or want to tune batch size
+# MOSHI_PER_BATCH_ITEM_MB=400


### PR DESCRIPTION
## Summary

Adds a `.env.example` file to document the required environment variables for moshi-server authentication.

## Changes

Created `.env.example` with:
- **MOSHI_API_KEY** - Comma-separated list of authorized API keys
- **BETTER_AUTH_SECRET** - JWT secret for Better Auth validation (optional)
- **MOSHI_MODEL_PARAMS_BILLIONS** - Model size hint for VRAM estimation
- **MOSHI_PER_BATCH_ITEM_MB** - VRAM per batch item estimate

## Usage

```bash
cp .env.example .env
# Edit .env with your values
source .env && moshi-server worker --config configs/config-stt-en-hf.toml
```

Fixes #29