### PR TITLE
feat: revamp logging with better timestamps, no ANSI in files, rotation

### DIFF
--- a/docs/MOSHI_SERVER_SETUP.md
+++ b/docs/MOSHI_SERVER_SETUP.md
@@ -75,7 +75,36 @@ moshi-server worker --config ...
   - Adjusts model paths to local cached assets.
   - Configures `BatchedAsr` with a safe initial batch size (e.g., 4 or 8), which is then auto-lowered by the server if needed.
 
-## 6. Building
+## 6. Logging
+
+The server uses `tracing` for structured logging with the following features:
+
+### Log Format
+- **Timestamps**: Human-readable format `YYYY-MM-DD HH:MM:SS.mmm` (e.g., `2025-12-02 01:36:42.113`)
+- **File output**: Clean text without ANSI color codes
+- **Console output**: Colored output for terminal readability
+
+### Log Rotation
+Logs are automatically rotated based on:
+- **Daily rotation**: New log file each day
+- **Size-based rotation**: Rotates when file exceeds `--log-max-size-mb` (default: 100 MB)
+- **File cleanup**: Keeps only `--log-max-files` rotated files (default: 10)
+
+Log files follow Debian-style naming: `log.instance`, `log.instance.1`, `log.instance.2`, etc.
+
+### CLI Options
+```bash
+moshi-server worker --config config.toml \
+  --log info \                    # Log level (trace, debug, info, warn, error)
+  --log-max-size-mb 100 \         # Max size per log file in MB
+  --log-max-files 10 \            # Max number of rotated log files to keep
+  --silent                        # Disable console output (file only)
+```
+
+### Log Directory
+Logs are written to the `log_dir` specified in the config file (e.g., `logs/moshi-server-rust/stt/`).
+
+## 7. Building
 
 To build the server with these changes:
 ```bash

--- a/moshi/rust/Cargo.lock
+++ b/moshi/rust/Cargo.lock
@@ -2773,6 +2773,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-appender",
+ "tracing-rolling-file",
  "tracing-subscriber",
  "vergen",
 ]
@@ -5100,11 +5101,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-rolling-file"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd38b6b03a92e4e311682054368ef79e7cb208c2125dd96647ef6bd7833de6db"
+dependencies = [
+ "chrono",
+ "tracing-appender",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
+ "chrono",
  "nu-ansi-term",
  "sharded-slab",
  "smallvec",

--- a/moshi/rust/Cargo.toml
+++ b/moshi/rust/Cargo.toml
@@ -78,7 +78,8 @@ tower-http = { version = "0.6", features = ["full"] }
 tracing = "0.1.43"
 tracing-appender = "0.2.4"
 tracing-chrome = "0.7.2"
-tracing-subscriber = "0.3.22"
+tracing-rolling-file = { version = "0.1.3", features = ["non-blocking"] }
+tracing-subscriber = { version = "0.3.22", features = ["chrono"] }
 tui-logger = "0.17.4"
 vergen = { version = "=8.3.2", features = ["build", "cargo", "git", "gitcl", "rustc", "si"] }
 

--- a/moshi/rust/moshi-server/Cargo.toml
+++ b/moshi/rust/moshi-server/Cargo.toml
@@ -50,6 +50,7 @@ tower = { workspace = true }
 tower-http = { workspace = true }
 tracing = { workspace = true }
 tracing-appender = { workspace = true }
+tracing-rolling-file = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [build-dependencies]


### PR DESCRIPTION
## Summary

Comprehensive logging revamp for moshi-server addressing all issues from #31.

## Changes

### Log Format
- **Timestamps**: Human-readable format `YYYY-MM-DD HH:MM:SS.mmm` (e.g., `2025-12-02 01:36:42.113`)
- **File output**: Clean text without ANSI color codes (fixes the weird `[2m`, `[32m`, `[0m` characters)
- **Console output**: Colored output preserved for terminal readability

### Log Rotation
- **Daily rotation**: New log file each day
- **Size-based rotation**: Rotates when file exceeds `--log-max-size-mb` (default: 100 MB)
- **File cleanup**: Keeps only `--log-max-files` rotated files (default: 10)
- **Debian-style naming**: `log.instance`, `log.instance.1`, `log.instance.2`, etc.

### New CLI Options
```bash
moshi-server worker --config config.toml \
  --log-max-size-mb 100 \    # Max size per log file in MB
  --log-max-files 10          # Max number of rotated log files to keep
```

### Dependencies
- Added `tracing-rolling-file` crate for advanced log rotation
- Enabled `chrono` feature in `tracing-subscriber` for custom timestamps

## Before/After

**Before** (log file with ANSI codes):
```
[2m2025-12-02T01:36:42.113551Z[0m [32m INFO[0m [2mmoshi_server[0m...
```

**After** (clean log file):
```
2025-12-02 01:36:42.113 INFO moshi_server::main:509 build_info=BuildInfo { ... }
```

## Testing
- `cargo check --features cuda` passes
- `cargo clippy --features cuda` passes (only pre-existing warnings)

Closes #31