### PR TITLE
feat(#38): Auto-load .env file on moshi-server startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # Moshi Server Environment Configuration
 # Copy this file to .env and fill in your values
-# Usage: source .env && moshi-server worker --config configs/config-stt-en-hf.toml
+# The server automatically loads .env on startup (no need to source manually)
+# Usage: moshi-server worker --config configs/config-stt-en-hf.toml
 
 # =============================================================================
 # AUTHENTICATION

--- a/docs/MOSHI_SERVER_SETUP.md
+++ b/docs/MOSHI_SERVER_SETUP.md
@@ -51,14 +51,28 @@ To prevent `CUDA_ERROR_OUT_OF_MEMORY` on the 8GB card, we implemented automatic 
 - `MOSHI_PER_BATCH_ITEM_MB`: Override VRAM per batch item estimate (default 400).
 - `MOSHI_API_KEY`: Comma-separated list of authorized API keys (replaces hardcoded `authorized_ids` in config).
 
-## 3. Authentication
+## 3. Environment Configuration
 
-The server now supports loading authorized keys from the `MOSHI_API_KEY` environment variable. This is preferred over hardcoding tokens in the configuration file.
+The server automatically loads environment variables from a `.env` file in the current working directory at startup using `dotenvy`. This eliminates the need to manually source the file before running.
 
+### Usage
+Simply create a `.env` file (see `.env.example` for template):
 ```bash
-export MOSHI_API_KEY="my_secret_token,another_token"
-moshi-server worker --config ...
+# .env
+MOSHI_API_KEY=my_secret_token,another_token
+BETTER_AUTH_SECRET=your_jwt_secret_here
 ```
+
+Then run the server directly:
+```bash
+moshi-server worker --config configs/config-stt-en-hf.toml
+```
+
+The `.env` file is loaded before any configuration parsing, so all environment variables are available for config resolution.
+
+### Authentication
+
+The server supports loading authorized keys from the `MOSHI_API_KEY` environment variable. This is preferred over hardcoding tokens in the configuration file.
 
 ## 4. Turing (RTX 20xx) Compatibility
 

--- a/moshi/rust/Cargo.lock
+++ b/moshi/rust/Cargo.lock
@@ -1196,6 +1196,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2743,6 +2749,7 @@ dependencies = [
  "candle-transformers",
  "chrono",
  "clap",
+ "dotenvy",
  "futures-util",
  "hf-hub",
  "jsonwebtoken",

--- a/moshi/rust/Cargo.toml
+++ b/moshi/rust/Cargo.toml
@@ -33,6 +33,7 @@ candle-nn = "0.9.1"
 candle-transformers = "0.9.1"
 clap = { version = "4.5.53", features = ["derive"] }
 color-eyre = "0.6.5"
+dotenvy = "0.15"
 cpal = "0.16.0"
 crossterm = { version = "0.29.0", features = ["event-stream"] }
 env_logger = "0.11.8"

--- a/moshi/rust/moshi-server/Cargo.toml
+++ b/moshi/rust/moshi-server/Cargo.toml
@@ -20,6 +20,7 @@ candle-nn = { workspace = true }
 chrono = { workspace = true }
 candle-transformers = { workspace = true }
 clap = { workspace = true }
+dotenvy = { workspace = true }
 futures-util = { workspace = true }
 hf-hub = { workspace = true }
 jsonwebtoken = { workspace = true }

--- a/moshi/rust/moshi-server/src/main.rs
+++ b/moshi/rust/moshi-server/src/main.rs
@@ -661,6 +661,9 @@ async fn main() {
 }
 
 async fn main_() -> Result<()> {
+    // Load .env file if present (before parsing args so env vars are available)
+    dotenvy::dotenv().ok();
+
     let args = <Args as clap::Parser>::parse();
     match args.command {
         Command::Configs { which } => match which.as_str() {


### PR DESCRIPTION
Closes #38

## Summary

Adds automatic  file loading to moshi-server using the `dotenvy` crate. This eliminates the need to manually `source .env` before running the server.

## Changes

- Added `dotenvy` dependency to workspace and moshi-server Cargo.toml
- Call `dotenvy::dotenv().ok()` at start of `main_()` before config loading
- Updated docs/MOSHI_SERVER_SETUP.md with new environment configuration section
- Updated .env.example to reflect auto-loading behavior
- Removed `export` prefix from .env variables (dotenvy doesn't need them)

## Testing

- `cargo check -p moshi-server` passes
- Environment variables are loaded before config parsing