### PR TITLE
feat(#43): Client Error Handling & UI

### DIFF
--- a/moshi/client/src/components/connection/ErrorBanner.tsx
+++ b/moshi/client/src/components/connection/ErrorBanner.tsx
@@ -1,0 +1,119 @@
+import type { FC } from "react";
+import type { ConnectionError } from "../../types/errors";
+
+interface ErrorBannerProps {
+  error: ConnectionError;
+  onRetry?: () => void;
+  onDismiss?: () => void;
+  retryCount?: number;
+  maxRetries?: number;
+}
+
+/**
+ * Gets the appropriate icon for an error category.
+ */
+function getErrorIcon(category: ConnectionError["category"]): string {
+  switch (category) {
+    case "authentication":
+      return "🔒";
+    case "capacity":
+      return "⏳";
+    case "timeout":
+      return "⏱️";
+    case "connection":
+      return "🔌";
+    case "protocol":
+      return "⚠️";
+    case "server":
+      return "🔧";
+    default:
+      return "❌";
+  }
+}
+
+/**
+ * Gets the appropriate background color class for an error category.
+ */
+function getErrorColorClass(category: ConnectionError["category"]): string {
+  switch (category) {
+    case "authentication":
+      return "bg-red-900/90";
+    case "capacity":
+      return "bg-yellow-900/90";
+    case "timeout":
+      return "bg-orange-900/90";
+    case "server":
+      return "bg-red-800/90";
+    default:
+      return "bg-gray-800/90";
+  }
+}
+
+/**
+ * Error banner component for displaying connection errors.
+ */
+export const ErrorBanner: FC<ErrorBannerProps> = ({
+  error,
+  onRetry,
+  onDismiss,
+  retryCount = 0,
+  maxRetries = 3,
+}) => {
+  const icon = getErrorIcon(error.category);
+  const colorClass = getErrorColorClass(error.category);
+  const canRetry = error.retryable && retryCount < maxRetries;
+
+  return (
+    <div
+      className={`${colorClass} rounded-lg border border-white/20 p-4 shadow-lg`}
+      role="alert"
+    >
+      <div className="flex items-start gap-3">
+        <span className="text-2xl" aria-hidden="true">
+          {icon}
+        </span>
+        <div className="flex-1">
+          <h3 className="font-semibold text-white">{error.message}</h3>
+          <p className="mt-1 text-sm text-white/80">{error.description}</p>
+
+          {error.code && (
+            <p className="mt-2 text-xs text-white/60">
+              Error code: {error.code}
+            </p>
+          )}
+
+          <div className="mt-3 flex gap-2">
+            {canRetry && onRetry && (
+              <button
+                type="button"
+                onClick={onRetry}
+                className="rounded bg-white/20 px-3 py-1 text-sm font-medium text-white hover:bg-white/30 transition-colors"
+              >
+                Retry {retryCount > 0 && `(${retryCount}/${maxRetries})`}
+              </button>
+            )}
+            {onDismiss && (
+              <button
+                type="button"
+                onClick={onDismiss}
+                className="rounded bg-white/10 px-3 py-1 text-sm text-white/80 hover:bg-white/20 transition-colors"
+              >
+                Dismiss
+              </button>
+            )}
+          </div>
+
+          {error.retryable && error.retryDelayMs && retryCount < maxRetries && (
+            <p className="mt-2 text-xs text-white/60">
+              {canRetry
+                ? `Will retry automatically in ${Math.round(error.retryDelayMs / 1000)}s`
+                : "Maximum retry attempts reached"}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ErrorBanner;

--- a/moshi/client/src/hooks/useAuth.ts
+++ b/moshi/client/src/hooks/useAuth.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { authClient, getSession } from "../lib/auth-client";
+import { authClient, getSession } from "../utils/auth-client";
 
 export interface User {
   id: string;

--- a/moshi/client/src/pages/Conversation/Conversation.tsx
+++ b/moshi/client/src/pages/Conversation/Conversation.tsx
@@ -1,11 +1,11 @@
 import {
-  type FC,
-  type MutableRefObject,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
+    type FC,
+    type MutableRefObject,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
 } from "react";
 import fixWebmDuration from "webm-duration-fix";
 import { Button } from "../../components/Button/Button";
@@ -281,7 +281,18 @@ export const Conversation: FC<ConversationProps> = ({
     stopRecording();
   }, [stopRecording]);
 
-  const { isConnected, sendMessage, socket, start, stop } = useSocket({
+  const {
+    isConnected,
+    isConnecting,
+    sendMessage,
+    socket,
+    start,
+    stop,
+    error,
+    clearError,
+    retryConnection,
+    retryCount,
+  } = useSocket({
     // onMessage,
     uri: WSURL,
     onDisconnect,
@@ -298,8 +309,13 @@ export const Conversation: FC<ConversationProps> = ({
     <SocketContext.Provider
       value={{
         isConnected,
+        isConnecting,
         sendMessage,
         socket,
+        error,
+        clearError,
+        retryConnection,
+        retryCount,
       }}
     >
       <MediaContext.Provider

--- a/moshi/client/src/pages/Conversation/SocketContext.ts
+++ b/moshi/client/src/pages/Conversation/SocketContext.ts
@@ -1,16 +1,27 @@
 import { createContext, useContext } from "react";
 import type { WSMessage } from "../../protocol/types";
+import type { ConnectionError } from "../../types/errors";
 
 type SocketContextType = {
   isConnected: boolean;
+  isConnecting: boolean;
   socket: WebSocket | null;
   sendMessage: (message: WSMessage) => void;
+  error: ConnectionError | null;
+  clearError: () => void;
+  retryConnection: () => void;
+  retryCount: number;
 };
 
 export const SocketContext = createContext<SocketContextType>({
   isConnected: false,
+  isConnecting: false,
   socket: null,
   sendMessage: () => {},
+  error: null,
+  clearError: () => {},
+  retryConnection: () => {},
+  retryCount: 0,
 });
 
 export const useSocketContext = () => {

--- a/moshi/client/src/pages/Conversation/hooks/useSocket.ts
+++ b/moshi/client/src/pages/Conversation/hooks/useSocket.ts
@@ -1,19 +1,37 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { decodeMessage, encodeMessage } from "../../../protocol/encoder";
 import type { WSMessage } from "../../../protocol/types";
+import type { ConnectionError } from "../../../types/errors";
+import {
+    parseCloseEvent,
+    parseErrorEvent,
+    calculateRetryDelay,
+} from "../../../utils/errors/parse-ws-error";
 
 export const useSocket = ({
   onMessage,
   uri,
   onDisconnect: onDisconnectProp,
+  onError: onErrorProp,
+  maxRetries = 3,
 }: {
   onMessage?: (message: WSMessage) => void;
   uri: string;
   onDisconnect?: () => void;
+  onError?: (error: ConnectionError) => void;
+  maxRetries?: number;
 }) => {
   const lastMessageTime = useRef<null | number>(null);
   const [isConnected, setIsConnected] = useState(false);
+  const [isConnecting, setIsConnecting] = useState(false);
   const [socket, setSocket] = useState<WebSocket | null>(null);
+  const [error, setError] = useState<ConnectionError | null>(null);
+  const [retryCount, setRetryCount] = useState(0);
+  const retryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearError = useCallback(() => {
+    setError(null);
+  }, []);
 
   const sendMessage = useCallback(
     (message: WSMessage) => {
@@ -28,16 +46,52 @@ export const useSocket = ({
 
   const onConnect = useCallback(() => {
     console.log("connected, now waiting for handshake.");
-    // setIsConnected(true);
-  }, []);
+    setIsConnecting(false);
+    setRetryCount(0);
+    clearError();
+  }, [clearError]);
 
-  const onDisconnect = useCallback(() => {
-    console.log("disconnected");
-    if (onDisconnectProp) {
-      onDisconnectProp();
-    }
-    setIsConnected(false);
-  }, [onDisconnectProp]);
+  const handleError = useCallback(
+    (connectionError: ConnectionError) => {
+      console.error("WebSocket error:", connectionError);
+      setError(connectionError);
+      setIsConnecting(false);
+      if (onErrorProp) {
+        onErrorProp(connectionError);
+      }
+    },
+    [onErrorProp],
+  );
+
+  const onCloseEvent = useCallback(
+    (event: CloseEvent) => {
+      console.log("WebSocket closed:", event.code, event.reason);
+      setIsConnected(false);
+      setIsConnecting(false);
+
+      // Parse the close event into a structured error
+      const connectionError = parseCloseEvent(event);
+
+      // Only set error if it's not a normal closure
+      if (event.code !== 1000) {
+        handleError(connectionError);
+      }
+
+      if (onDisconnectProp) {
+        onDisconnectProp();
+      }
+    },
+    [onDisconnectProp, handleError],
+  );
+
+  const onErrorEvent = useCallback(
+    (event: Event) => {
+      console.error("WebSocket error event:", event);
+      const connectionError = parseErrorEvent(event);
+      handleError(connectionError);
+    },
+    [handleError],
+  );
 
   const onMessageEvent = useCallback(
     (eventData: MessageEvent) => {
@@ -47,6 +101,7 @@ export const useSocket = ({
       if (message.type === "handshake") {
         console.log("Handshake received, let's rocknroll.");
         setIsConnected(true);
+        setIsConnecting(false);
       }
       if (!onMessage) {
         return;
@@ -57,25 +112,69 @@ export const useSocket = ({
   );
 
   const start = useCallback(() => {
+    // Clear any pending retry
+    if (retryTimeoutRef.current) {
+      clearTimeout(retryTimeoutRef.current);
+      retryTimeoutRef.current = null;
+    }
+
+    setIsConnecting(true);
+    clearError();
+
     const ws = new WebSocket(uri);
     ws.binaryType = "arraybuffer";
     ws.addEventListener("open", onConnect);
-    ws.addEventListener("close", onDisconnect);
+    ws.addEventListener("close", onCloseEvent);
+    ws.addEventListener("error", onErrorEvent);
     ws.addEventListener("message", onMessageEvent);
     setSocket(ws);
     console.log("Socket created", ws);
     lastMessageTime.current = Date.now();
-  }, [uri, onConnect, onDisconnect, onMessageEvent]);
+  }, [uri, onConnect, onCloseEvent, onErrorEvent, onMessageEvent, clearError]);
 
   const stop = useCallback(() => {
+    // Clear any pending retry
+    if (retryTimeoutRef.current) {
+      clearTimeout(retryTimeoutRef.current);
+      retryTimeoutRef.current = null;
+    }
+
     setIsConnected(false);
+    setIsConnecting(false);
     if (onDisconnectProp) {
       onDisconnectProp();
     }
-    socket?.close();
+    socket?.close(1000, "Client requested disconnect");
     setSocket(null);
   }, [socket, onDisconnectProp]);
 
+  const retryConnection = useCallback(() => {
+    if (retryCount >= maxRetries) {
+      console.log("Max retries reached, not retrying");
+      return;
+    }
+
+    const delay = calculateRetryDelay(retryCount);
+    console.log(`Retrying connection in ${delay}ms (attempt ${retryCount + 1}/${maxRetries})`);
+
+    setRetryCount((prev) => prev + 1);
+    clearError();
+
+    retryTimeoutRef.current = setTimeout(() => {
+      start();
+    }, delay);
+  }, [retryCount, maxRetries, start, clearError]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (retryTimeoutRef.current) {
+        clearTimeout(retryTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  // Inactivity timeout
   useEffect(() => {
     if (!isConnected) {
       return;
@@ -86,8 +185,7 @@ export const useSocket = ({
         Date.now() - lastMessageTime.current > 10000
       ) {
         console.log("closing socket due to inactivity", socket);
-        socket?.close();
-        onDisconnect();
+        socket?.close(4006, "Client inactivity timeout");
         clearInterval(intervalId);
       }
     }, 500);
@@ -96,13 +194,18 @@ export const useSocket = ({
       lastMessageTime.current = null;
       clearInterval(intervalId);
     };
-  }, [isConnected, socket, onDisconnect]);
+  }, [isConnected, socket]);
 
   return {
     isConnected,
+    isConnecting,
     socket,
     sendMessage,
     start,
     stop,
+    error,
+    clearError,
+    retryConnection,
+    retryCount,
   };
 };

--- a/moshi/client/src/types/errors.ts
+++ b/moshi/client/src/types/errors.ts
@@ -1,0 +1,105 @@
+/**
+ * WebSocket close codes used by moshi-server.
+ * Standard codes (1000-1015) are defined by RFC 6455.
+ * Custom application codes (4000-4999) are defined by the server.
+ */
+export enum CloseCode {
+  // Standard RFC 6455 codes
+  Normal = 1000,
+  GoingAway = 1001,
+  ProtocolError = 1002,
+  UnsupportedData = 1003,
+  NoStatus = 1005,
+  AbnormalClosure = 1006,
+  InvalidPayload = 1007,
+  PolicyViolation = 1008,
+  MessageTooBig = 1009,
+  MandatoryExtension = 1010,
+  InternalError = 1011,
+  ServiceRestart = 1012,
+  TryAgainLater = 1013,
+  BadGateway = 1014,
+  TlsHandshake = 1015,
+
+  // Custom moshi-server codes (4000-4999)
+  ServerAtCapacity = 4000,
+  AuthenticationFailed = 4001,
+  SessionTimeout = 4002,
+  InvalidMessage = 4003,
+  RateLimited = 4004,
+  ResourceUnavailable = 4005,
+  ClientTimeout = 4006,
+}
+
+/**
+ * Error categories for UI display and retry logic.
+ */
+export type ErrorCategory =
+  | "connection"
+  | "authentication"
+  | "capacity"
+  | "timeout"
+  | "protocol"
+  | "server"
+  | "unknown";
+
+/**
+ * Structured connection error with all relevant information.
+ */
+export interface ConnectionError {
+  /** Error category for UI display */
+  category: ErrorCategory;
+  /** WebSocket close code (if available) */
+  code?: number;
+  /** Human-readable error message */
+  message: string;
+  /** Detailed description for debugging */
+  description: string;
+  /** Whether the client should retry the connection */
+  retryable: boolean;
+  /** Suggested retry delay in milliseconds (if retryable) */
+  retryDelayMs?: number;
+  /** Original error event (if available) */
+  originalEvent?: Event | CloseEvent;
+  /** Timestamp when error occurred */
+  timestamp: Date;
+}
+
+/**
+ * Server status response from /api/status endpoint.
+ */
+export interface ServerStatus {
+  status: "healthy" | "degraded" | "unhealthy";
+  uptime_seconds: number;
+  started_at: string;
+  build: {
+    build_timestamp: string;
+    git_hash: string;
+    rustc_version: string;
+    [key: string]: string;
+  };
+  capacity: {
+    total_slots: number;
+    used_slots: number;
+    available_slots: number;
+    modules: Array<{
+      name: string;
+      module_type: string;
+      total_slots: number;
+      used_slots: number;
+      available_slots: number;
+    }>;
+  };
+  auth: {
+    api_key_configured: boolean;
+    better_auth_enabled: boolean;
+  };
+}
+
+/**
+ * Health check response from /api/health endpoint.
+ */
+export interface HealthResponse {
+  status: "ok" | "error";
+  uptime_seconds: number;
+}

--- a/moshi/client/src/utils/auth-client.ts
+++ b/moshi/client/src/utils/auth-client.ts
@@ -1,0 +1,40 @@
+import { createAuthClient } from "better-auth/react";
+
+/**
+ * Better Auth client instance for the Moshi web client.
+ *
+ * This client handles:
+ * - User authentication (sign in, sign up, sign out)
+ * - Session management
+ * - Automatic token refresh
+ *
+ * The client communicates with the Better Auth server at the configured base URL.
+ * By default, it uses the same origin as the client (for same-domain deployments).
+ *
+ * For cross-origin deployments, set VITE_AUTH_URL environment variable.
+ */
+export const authClient = createAuthClient({
+  // Base URL of the auth server
+  // If not set, defaults to same origin (e.g., http://localhost:3000/api/auth)
+  baseURL: import.meta.env.VITE_AUTH_URL || undefined,
+});
+
+// Export commonly used methods for convenience
+export const { signIn, signUp, signOut, useSession, getSession } = authClient;
+
+/**
+ * Get the current session token for API requests.
+ * This can be used to authenticate WebSocket connections or HTTP requests.
+ *
+ * @returns The session token if authenticated, null otherwise
+ */
+export async function getSessionToken(): Promise<string | null> {
+  const session = await getSession();
+  if (!session.data) {
+    return null;
+  }
+  // The session token is stored in cookies by Better Auth
+  // For WebSocket auth, we need to pass it as a query parameter
+  // since browsers don't allow custom headers on WebSocket connections
+  return session.data.session.token;
+}

--- a/moshi/client/src/utils/errors/parse-ws-error.ts
+++ b/moshi/client/src/utils/errors/parse-ws-error.ts
@@ -1,0 +1,247 @@
+import {
+    CloseCode,
+    type ConnectionError,
+    type ErrorCategory,
+} from "../../types/errors";
+
+/**
+ * Base retry delay in milliseconds for exponential backoff.
+ */
+const BASE_RETRY_DELAY_MS = 1000;
+
+/**
+ * Maximum retry delay in milliseconds.
+ */
+const MAX_RETRY_DELAY_MS = 30000;
+
+/**
+ * Maps a WebSocket close code to an error category.
+ */
+function getErrorCategory(code: number): ErrorCategory {
+  switch (code) {
+    case CloseCode.Normal:
+    case CloseCode.GoingAway:
+      return "connection";
+
+    case CloseCode.AuthenticationFailed:
+      return "authentication";
+
+    case CloseCode.ServerAtCapacity:
+    case CloseCode.RateLimited:
+      return "capacity";
+
+    case CloseCode.SessionTimeout:
+    case CloseCode.ClientTimeout:
+      return "timeout";
+
+    case CloseCode.ProtocolError:
+    case CloseCode.InvalidMessage:
+    case CloseCode.InvalidPayload:
+    case CloseCode.UnsupportedData:
+      return "protocol";
+
+    case CloseCode.InternalError:
+    case CloseCode.ServiceRestart:
+    case CloseCode.TryAgainLater:
+    case CloseCode.BadGateway:
+      return "server";
+
+    case CloseCode.AbnormalClosure:
+    case CloseCode.NoStatus:
+    default:
+      return "unknown";
+  }
+}
+
+/**
+ * Determines if an error is retryable based on close code.
+ */
+function isRetryable(code: number): boolean {
+  switch (code) {
+    // Retryable errors
+    case CloseCode.ServerAtCapacity:
+    case CloseCode.GoingAway:
+    case CloseCode.InternalError:
+    case CloseCode.RateLimited:
+    case CloseCode.SessionTimeout:
+    case CloseCode.ClientTimeout:
+    case CloseCode.ServiceRestart:
+    case CloseCode.TryAgainLater:
+    case CloseCode.AbnormalClosure:
+      return true;
+
+    // Non-retryable errors
+    case CloseCode.Normal:
+    case CloseCode.AuthenticationFailed:
+    case CloseCode.InvalidMessage:
+    case CloseCode.ProtocolError:
+    case CloseCode.ResourceUnavailable:
+    case CloseCode.PolicyViolation:
+    default:
+      return false;
+  }
+}
+
+/**
+ * Gets a human-readable message for a close code.
+ */
+function getErrorMessage(code: number, reason?: string): string {
+  // Use server-provided reason if available
+  if (reason && reason.trim()) {
+    return reason;
+  }
+
+  switch (code) {
+    case CloseCode.Normal:
+      return "Connection closed normally";
+    case CloseCode.GoingAway:
+      return "Server is shutting down";
+    case CloseCode.ProtocolError:
+      return "Protocol error";
+    case CloseCode.InternalError:
+      return "Server encountered an error";
+    case CloseCode.ServerAtCapacity:
+      return "Server is at capacity";
+    case CloseCode.AuthenticationFailed:
+      return "Authentication failed";
+    case CloseCode.SessionTimeout:
+      return "Session timed out";
+    case CloseCode.InvalidMessage:
+      return "Invalid message format";
+    case CloseCode.RateLimited:
+      return "Too many requests";
+    case CloseCode.ResourceUnavailable:
+      return "Resource not available";
+    case CloseCode.ClientTimeout:
+      return "Connection timed out";
+    case CloseCode.AbnormalClosure:
+      return "Connection lost unexpectedly";
+    case CloseCode.NoStatus:
+      return "Connection closed without status";
+    default:
+      return `Connection closed (code: ${code})`;
+  }
+}
+
+/**
+ * Gets a detailed description for debugging.
+ */
+function getErrorDescription(code: number): string {
+  switch (code) {
+    case CloseCode.Normal:
+      return "The connection was closed cleanly by either the client or server.";
+    case CloseCode.GoingAway:
+      return "The server is going away, either because of a server shutdown or navigating away from the page.";
+    case CloseCode.ServerAtCapacity:
+      return "The server has no available processing slots. Try again in a few moments.";
+    case CloseCode.AuthenticationFailed:
+      return "Your authentication credentials are invalid or expired. Please sign in again.";
+    case CloseCode.SessionTimeout:
+      return "Your session has exceeded the maximum allowed duration.";
+    case CloseCode.ClientTimeout:
+      return "The server did not receive data from your client within the expected timeframe.";
+    case CloseCode.RateLimited:
+      return "You have made too many requests. Please wait before trying again.";
+    case CloseCode.InvalidMessage:
+      return "The client sent a message that the server could not understand.";
+    case CloseCode.InternalError:
+      return "The server encountered an unexpected error. Our team has been notified.";
+    case CloseCode.AbnormalClosure:
+      return "The connection was lost unexpectedly. This may be due to network issues.";
+    default:
+      return `The connection was closed with code ${code}.`;
+  }
+}
+
+/**
+ * Calculates retry delay with exponential backoff.
+ */
+export function calculateRetryDelay(attemptNumber: number): number {
+  const delay = Math.min(
+    BASE_RETRY_DELAY_MS * Math.pow(2, attemptNumber),
+    MAX_RETRY_DELAY_MS
+  );
+  // Add jitter (±20%)
+  const jitter = delay * 0.2 * (Math.random() * 2 - 1);
+  return Math.round(delay + jitter);
+}
+
+/**
+ * Parses a WebSocket CloseEvent into a structured ConnectionError.
+ */
+export function parseCloseEvent(event: CloseEvent): ConnectionError {
+  const code = event.code;
+  const category = getErrorCategory(code);
+  const retryable = isRetryable(code);
+
+  return {
+    category,
+    code,
+    message: getErrorMessage(code, event.reason),
+    description: getErrorDescription(code),
+    retryable,
+    retryDelayMs: retryable ? calculateRetryDelay(0) : undefined,
+    originalEvent: event,
+    timestamp: new Date(),
+  };
+}
+
+/**
+ * Parses a WebSocket error event into a structured ConnectionError.
+ */
+export function parseErrorEvent(event: Event): ConnectionError {
+  return {
+    category: "connection",
+    message: "Connection error",
+    description:
+      "An error occurred while connecting to the server. Please check your network connection.",
+    retryable: true,
+    retryDelayMs: calculateRetryDelay(0),
+    originalEvent: event,
+    timestamp: new Date(),
+  };
+}
+
+/**
+ * Creates a ConnectionError for a pre-flight check failure.
+ */
+export function createPreflightError(
+  status: "unavailable" | "at_capacity" | "network_error",
+  details?: string
+): ConnectionError {
+  switch (status) {
+    case "unavailable":
+      return {
+        category: "server",
+        message: "Server unavailable",
+        description:
+          details || "The server is not responding. Please try again later.",
+        retryable: true,
+        retryDelayMs: calculateRetryDelay(0),
+        timestamp: new Date(),
+      };
+    case "at_capacity":
+      return {
+        category: "capacity",
+        code: CloseCode.ServerAtCapacity,
+        message: "Server at capacity",
+        description:
+          details ||
+          "The server is currently at capacity. Please try again in a few moments.",
+        retryable: true,
+        retryDelayMs: calculateRetryDelay(0),
+        timestamp: new Date(),
+      };
+    case "network_error":
+      return {
+        category: "connection",
+        message: "Network error",
+        description:
+          details ||
+          "Could not reach the server. Please check your internet connection.",
+        retryable: true,
+        retryDelayMs: calculateRetryDelay(0),
+        timestamp: new Date(),
+      };
+  }
+}


### PR DESCRIPTION
Closes #43

## Summary

Implements client-side error handling for WebSocket connections with proper UI feedback and retry logic.

## Changes

### New Files
- `types/errors.ts` - CloseCode enum, ConnectionError interface, ServerStatus types
- `utils/errors/parse-ws-error.ts` - Error parsing, retry delay calculation
- `components/connection/ErrorBanner.tsx` - Error display component

### Modified Files
- `useSocket.ts` - Added error handling, retry logic, connecting state
- `SocketContext.ts` - Added error state and retry functionality
- `Conversation.tsx` - Uses new socket properties

## Features

- **Error Parsing**: WebSocket close events parsed into structured ConnectionError objects
- **Retry Logic**: Exponential backoff with jitter for retryable errors
- **Error Categories**: connection, authentication, capacity, timeout, protocol, server, unknown
- **ErrorBanner Component**: Visual error display with retry/dismiss buttons

## Testing

- `pnpm exec tsc --noEmit` passes