### PR TITLE
feat(#44): Error Logging & Observability

### DIFF
--- a/docs/MOSHI_SERVER_SETUP.md
+++ b/docs/MOSHI_SERVER_SETUP.md
@@ -236,3 +236,40 @@ Before establishing a WebSocket connection, clients should:
 1. Call `GET /api/status` to check server availability
 2. Check `capacity.available_slots > 0` before connecting
 3. Display appropriate UI if server is at capacity
+## 11. Error Metrics & Observability
+
+The server exposes Prometheus metrics for error tracking and observability at `/metrics`.
+
+### Error Counters
+
+| Metric | Labels | Description |
+|--------|--------|-------------|
+| `ws_close_total` | code, reason | WebSocket close events by close code |
+| `connection_error_total` | error_type, module | Connection errors by type and module |
+| `auth_error_total` | error_type | Authentication errors by type |
+
+### Error Types
+
+**Connection Errors** (`connection_error_total`):
+- `capacity` - Server at capacity (no free channels)
+- `timeout` - Connection timeout
+- `protocol` - Protocol error
+- `internal` - Internal server error
+
+**Auth Errors** (`auth_error_total`):
+- `authentication_failed` - No valid authentication method found
+- `invalid_key` - Invalid API key
+- `expired_token` - Expired JWT token
+- `jwt_validation_failed` - JWT validation failed
+
+### Structured Logging
+
+All errors use structured logging with consistent fields:
+- `error_type` - Category of error
+- `module` - Module where error occurred (for connection errors)
+- Additional context-specific fields
+
+Example log output:
+```
+2025-12-08T23:00:00Z ERROR moshi_server::batched_asr error_type="capacity" module="batched_asr" no free channels - server at capacity
+```

--- a/moshi/rust/moshi-server/src/auth.rs
+++ b/moshi/rust/moshi-server/src/auth.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::sync::OnceLock;
 
-use crate::metrics;
+use crate::metrics::errors as error_metrics;
 
 /// Header for legacy API key authentication
 pub const ID_HEADER: &str = "kyutai-api-key";
@@ -117,9 +117,7 @@ impl AuthError {
 impl IntoResponse for AuthError {
     fn into_response(self) -> Response {
         // Increment Prometheus counter with error type label
-        metrics::auth::ERROR_TOTAL
-            .with_label_values(&[self.error_type()])
-            .inc();
+        error_metrics::record_auth_error(self.error_type());
 
         (StatusCode::UNAUTHORIZED, Json(self)).into_response()
     }


### PR DESCRIPTION
Closes #44

## Summary

Adds comprehensive error metrics and observability for moshi-server with Prometheus counters and structured logging.

## Changes

### New Error Metrics Module (`metrics/errors`)
- `ws_close_total` - WebSocket close events by close code (labels: code, reason)
- `connection_error_total` - Connection errors by type and module (labels: error_type, module)
- `auth_error_total` - Authentication errors by type (labels: error_type)

### Helper Functions
- `record_ws_close(code, reason)` - Record WebSocket close event
- `record_connection_error(error_type, module)` - Record connection error
- `record_auth_error(error_type)` - Record authentication error

### Updated Modules
- `auth.rs` - Records authentication failures
- `batched_asr.rs` - Records capacity errors with structured logging
- `py_basr_module.rs` - Records capacity errors with structured logging

### Documentation
- Added Section 9 to docs/MOSHI_SERVER_SETUP.md

## Testing

- `cargo check -p moshi-server` passes