### PR TITLE
feat: remove legacy MOSHI_API_KEY authentication

### DIFF
--- a/.agent/agent-state.json
+++ b/.agent/agent-state.json
@@ -1,30 +1,30 @@
 {
-  "phase": "merging",
-  "epic_issue": 69,
+  "phase": "implementing",
+  "epic_issue": null,
   "issues": [
     {
-      "number": 70,
-      "title": "Enhanced Logging System with Aesthetic Improvements",
-      "branch": "feat/issue-70-enhanced-logging",
-      "status": "complete",
-      "pr_number": 72,
-      "completed_at": "2025-12-09T17:40:00Z"
-    },
-    {
-      "number": 71,
-      "title": "Performance Optimization Research & Implementation",
-      "branch": "feat/issue-71-performance-optimization",
-      "status": "complete",
-      "pr_number": 73,
-      "completed_at": "2025-12-09T18:00:00Z"
+      "number": 74,
+      "title": "Remove legacy MOSHI_API_KEY authentication",
+      "branch": "feat/issue-74-remove-moshi-api-key",
+      "tasks": [
+        {"description": "Remove MOSHI_API_KEY from .env and .env.example", "done": false},
+        {"description": "Remove MOSHI_API_KEY comments from config TOML files", "done": false},
+        {"description": "Update Python scripts to remove --api-key default", "done": false},
+        {"description": "Update documentation files", "done": false},
+        {"description": "Remove legacy API key code from auth.rs", "done": false}
+      ],
+      "current_task_index": 0,
+      "status": "in_progress",
+      "pr_number": null,
+      "started_at": "2025-12-09T23:30:00Z"
     }
   ],
-  "current_issue_index": 1,
+  "current_issue_index": 0,
   "repository": {
     "owner": "grantjr1842",
     "name": "delayed-streams-modeling",
     "full_name": "grantjr1842/delayed-streams-modeling",
     "default_branch": "main"
   },
-  "last_updated": "2025-12-09T18:00:00Z"
+  "last_updated": "2025-12-09T23:30:00Z"
 }

--- a/.env.example
+++ b/.env.example
@@ -7,10 +7,10 @@
 # AUTHENTICATION
 # =============================================================================
 
-# API Key Authentication (Legacy)
-# Comma-separated list of authorized API keys for the kyutai-api-key header
-# Generate a secure random key: openssl rand -hex 32
-MOSHI_API_KEY=your_api_key_here
+# Better Auth JWT Secret
+# MUST be identical to the secret in moshi/auth-server/.env for JWT validation
+# Generate with: openssl rand -base64 32
+BETTER_AUTH_SECRET=your_better_auth_secret_here
 
 # =============================================================================
 # VRAM / GPU CONFIGURATION (Optional)

--- a/configs/config-stt-en-hf.toml
+++ b/configs/config-stt-en-hf.toml
@@ -1,7 +1,7 @@
 static_dir = "./static/"
 log_dir = "logs/moshi-server-rust/stt"
 instance_name = "config-stt-en-hf"
-# authorized_ids can be set here or via MOSHI_API_KEY environment variable (comma-separated)
+# Authentication is handled by Better Auth JWT (BETTER_AUTH_SECRET env var)
 authorized_ids = []
 warmup = { enabled = true } # eager warmup at startup (set false to skip)
 

--- a/configs/config-stt-en_fr-hf.toml
+++ b/configs/config-stt-en_fr-hf.toml
@@ -1,7 +1,7 @@
 static_dir = "./static/"
 log_dir = "logs/moshi-server-rust/stt"
 instance_name = "config-stt-en_fr-hf"
-# authorized_ids can be set here or via MOSHI_API_KEY environment variable (comma-separated)
+# Authentication is handled by Better Auth JWT (BETTER_AUTH_SECRET env var)
 authorized_ids = []
 
 [modules.asr]

--- a/configs/config-stt-en_fr-lowram-sm75.toml
+++ b/configs/config-stt-en_fr-lowram-sm75.toml
@@ -1,7 +1,7 @@
 static_dir = "../client/dist"
 log_dir = "logs/moshi-server-rust/stt"
 instance_name = "config-stt-en_fr-lowram-sm75"
-# authorized_ids can be set here or via MOSHI_API_KEY environment variable (comma-separated)
+# Authentication is handled by Better Auth JWT (BETTER_AUTH_SECRET env var)
 authorized_ids = []
 
 [modules.asr]

--- a/configs/config-tts.toml
+++ b/configs/config-tts.toml
@@ -2,11 +2,7 @@ static_dir = "./static/"
 log_dir = "logs/moshi-server-rust/tts"
 # Used to identify the server when logging.
 instance_name = "tts"
-# Simple security: require clients to provide an auth token when connecting.
-# It can be set by setting auth_id to the query string, e.g.
-# "localhost:8089/api/tts_streaming?auth_id=public_token"
-# or by setting the kyutai-api-key HTTP header, see the tts_rust_server.py example.
-# authorized_ids can be set here or via MOSHI_API_KEY environment variable (comma-separated)
+# Authentication is handled by Better Auth JWT (BETTER_AUTH_SECRET env var)
 authorized_ids = []
 
 [modules.tts_py]

--- a/docs/BETTER_AUTH_INTEGRATION.md
+++ b/docs/BETTER_AUTH_INTEGRATION.md
@@ -4,11 +4,11 @@ This document describes how to integrate Better Auth for user authentication wit
 
 ## Overview
 
-The moshi-server supports multiple authentication methods:
+The moshi-server uses Better Auth for authentication:
 
-1. **Legacy API Key** - Simple API key via `kyutai-api-key` header or `auth_id` query parameter
-2. **Better Auth JWT** - JWT tokens from Better Auth's cookie cache feature
-3. **Session Cookie** - Better Auth session cookies (for same-origin deployments)
+1. **Better Auth JWT** - JWT tokens from Better Auth's cookie cache feature
+2. **Session Cookie** - Better Auth session cookies (for same-origin deployments)
+3. **JWT Query Parameter** - For WebSocket connections where headers are difficult to set
 
 ## Server Configuration
 
@@ -16,13 +16,11 @@ The moshi-server supports multiple authentication methods:
 
 | Variable | Description | Required |
 |----------|-------------|----------|
-| `MOSHI_API_KEY` | Comma-separated list of valid API keys | No |
-| `BETTER_AUTH_SECRET` | Shared secret with Better Auth for JWT validation | No (but required for JWT auth) |
+| `BETTER_AUTH_SECRET` | Shared secret with Better Auth for JWT validation | Yes |
 
 ### Example
 
 ```bash
-export MOSHI_API_KEY="key1,key2,key3"
 export BETTER_AUTH_SECRET="your-32-character-secret-here"
 
 moshi-server worker --config configs/config-stt-en-hf.toml
@@ -118,7 +116,7 @@ function MyComponent() {
 
 ### WebSocket Authentication
 
-The session token is automatically passed to WebSocket connections via the `auth_id` query parameter:
+The session token is automatically passed to WebSocket connections via the `token` query parameter:
 
 ```typescript
 // In Conversation.tsx
@@ -177,15 +175,14 @@ The moshi-server expects the following claims in the Better Auth JWT:
 }
 ```
 
-## Backward Compatibility
+## Programmatic Access
 
-The legacy API key authentication continues to work alongside Better Auth:
+For programmatic API access (e.g., Python scripts), obtain a JWT token from the Better Auth server and pass it via:
 
-- API keys can be passed via `kyutai-api-key` header
-- API keys can be passed via `auth_id` query parameter
-- Both methods are checked before JWT validation
+- `Authorization: Bearer <token>` header
+- `?token=<token>` query parameter
 
-This allows programmatic API access while web users authenticate via Better Auth.
+This allows scripts and automated tools to authenticate the same way as web users.
 
 ## Troubleshooting
 

--- a/docs/MOSHI_SERVER_SETUP.md
+++ b/docs/MOSHI_SERVER_SETUP.md
@@ -52,7 +52,6 @@ To prevent `CUDA_ERROR_OUT_OF_MEMORY` on the 8GB card, we implemented automatic 
 - `MOSHI_MODEL_PARAMS_BILLIONS`: Override model size hint (default 1.0).
 - `MOSHI_PER_BATCH_ITEM_MB`: Override VRAM per batch item estimate (default 600, scales with dtype).
 - `MOSHI_VRAM_RESERVED_MB`: Override reserved VRAM (default 2048).
-- `MOSHI_API_KEY`: Comma-separated list of authorized API keys (replaces hardcoded `authorized_ids` in config).
 
 ## 3. Environment Configuration
 
@@ -62,7 +61,6 @@ The server automatically loads environment variables from a `.env` file in the c
 Simply create a `.env` file (see `.env.example` for template):
 ```bash
 # .env
-MOSHI_API_KEY=my_secret_token,another_token
 BETTER_AUTH_SECRET=your_jwt_secret_here
 ```
 
@@ -75,15 +73,13 @@ The `.env` file is loaded before any configuration parsing, so all environment v
 
 ### Authentication
 
-The server supports multiple authentication methods, with priority order:
+The server uses Better Auth for authentication. Supported methods:
 
-1. **Legacy API Key** - Via `kyutai-api-key` header or `auth_id` query parameter
-2. **Bearer Token** - Via `Authorization: Bearer <jwt>` header
-3. **JWT Query Parameter** - Via `?token=<jwt>` query parameter (useful for WebSockets where setting headers is difficult)
-4. **Session Cookie** - Via `better-auth.session_token` cookie
+1. **Bearer Token** - Via `Authorization: Bearer <jwt>` header
+2. **JWT Query Parameter** - Via `?token=<jwt>` query parameter (useful for WebSockets where setting headers is difficult)
+3. **Session Cookie** - Via `better-auth.session_token` cookie
 
 **Environment Variables:**
-- `MOSHI_API_KEY`: Comma-separated list of authorized API keys
 - `BETTER_AUTH_SECRET`: JWT secret for Better Auth validation (must match auth-server)
 
 ### User Approval Status

--- a/moshi/rust/moshi-server/README.md
+++ b/moshi/rust/moshi-server/README.md
@@ -10,28 +10,7 @@ See [REVERSE_PROXY_SETUP.md](../../../docs/REVERSE_PROXY_SETUP.md) for configura
 
 ## Authentication
 
-The server supports multiple authentication methods:
-
-1. **API Key** - Simple API key via header or query parameter
-2. **Better Auth JWT** - JWT tokens from Better Auth's cookie cache feature
-3. **Session Cookie** - Better Auth session cookies
-
-### API Key Authentication
-
-Set the `MOSHI_API_KEY` environment variable to a comma-separated list of authorized keys.
-
-```bash
-export MOSHI_API_KEY="secret_token_1,secret_token_2"
-moshi-server worker --config config.toml ...
-```
-
-API keys can be passed via:
-- `kyutai-api-key` HTTP header
-- `auth_id` query parameter
-
-### Better Auth JWT Authentication
-
-For web applications using [Better Auth](https://www.better-auth.com/), set the `BETTER_AUTH_SECRET` environment variable to the same secret used by your Better Auth server.
+The server uses Better Auth for authentication. Set the `BETTER_AUTH_SECRET` environment variable to the same secret used by your Better Auth server.
 
 ```bash
 export BETTER_AUTH_SECRET="your-32-character-secret-here"
@@ -41,14 +20,6 @@ moshi-server worker --config config.toml ...
 The server validates JWTs from:
 - `Authorization: Bearer <token>` header
 - `better-auth.session_token` cookie
-- `auth_id` query parameter (for WebSocket connections)
+- `?token=<jwt>` query parameter (for WebSocket connections)
 
 See [BETTER_AUTH_INTEGRATION.md](../../../docs/BETTER_AUTH_INTEGRATION.md) for detailed setup instructions.
-
-### Configuration File
-
-You can also set `authorized_ids` in the configuration file, but using environment variables is recommended to avoid hardcoding secrets.
-
-```toml
-authorized_ids = ["secret_token_1"]
-```


### PR DESCRIPTION
## Summary

Removes the legacy `MOSHI_API_KEY` authentication mechanism since the project now uses Better Auth for all authentication.

## Changes

### Environment Files
- Removed `MOSHI_API_KEY` from `.env.example`

### Config Files
- Updated auth comments in TOML configs to reference Better Auth

### Python Scripts
- Replaced `--api-key` with `--token` flag for Better Auth JWT authentication
- Scripts now pass tokens via `?token=` query parameter

### Rust Code (`auth.rs`)
- Removed `ID_HEADER` constant (`kyutai-api-key`)
- Removed `AuthErrorCode::InvalidKey` variant
- Simplified `AuthConfig` struct (removed `authorized_ids`)
- Updated `AuthConfig::from_env()` to only load `BETTER_AUTH_SECRET`
- Simplified `auth::check()` and `auth::check_with_user()` signatures
- Removed legacy API key tests

### Rust Code (`main.rs`)
- Removed `authorized_ids` from `Config` struct
- Updated all `auth::check` and `auth::check_with_user` calls

### Documentation
- Updated `docs/MOSHI_SERVER_SETUP.md`
- Updated `docs/BETTER_AUTH_INTEGRATION.md`
- Updated `moshi/rust/moshi-server/README.md`

## Testing

- `cargo check --features cuda` passes

Closes #74