### PR TITLE
perf(moshi-core): Tensor allocation and contiguity optimizations

### DIFF
--- a/server/rust/moshi/moshi-core/src/asr.rs
+++ b/server/rust/moshi/moshi-core/src/asr.rs
@@ -165,16 +165,16 @@ impl State {
             for (batch_idx, item) in self.batch.iter().enumerate() {
                 if item.is_first_step() {
                     let pad = Tensor::full(item.audio_pad_token, (1, codebooks), &self.device)?;
-                    next_tokens_t = next_tokens_t.slice_assign(&[batch_idx..batch_idx+1], &pad)?;
+                    next_tokens_t = next_tokens_t.slice_assign(&[batch_idx..=batch_idx], &pad)?;
                 }
                 if mask.is_active(batch_idx) {
                     let step_tokens = audio_step_tokens.narrow(0, batch_idx, 1)?;
-                    self.next_codebooks = self.next_codebooks.slice_assign(&[batch_idx..batch_idx+1], &step_tokens)?;
+                    self.next_codebooks = self.next_codebooks.slice_assign(&[batch_idx..=batch_idx], &step_tokens)?;
                 }
             }
 
             let audio_tokens = (0..codebooks)
-                .map(|i| Ok(next_tokens_t.narrow(1, i, 1)?))
+                .map(|i| next_tokens_t.narrow(1, i, 1))
                 .collect::<Result<Vec<_>>>()?;
             let text = self.text_tokens()?;
             f(self.batch.as_slice(), &text, &audio_tokens);

--- a/server/rust/moshi/moshi-core/src/batched_transformer.rs
+++ b/server/rust/moshi/moshi-core/src/batched_transformer.rs
@@ -101,7 +101,7 @@ impl StreamingMultiheadAttention {
             let v = v.narrow(2, k_len - k_target_len, k_target_len)?;
             (k, v)
         } else {
-            (k.clone(), v.clone())
+            (k, v)
         };
 
         let xs = {

--- a/server/rust/moshi/moshi-core/src/conv.rs
+++ b/server/rust/moshi/moshi-core/src/conv.rs
@@ -273,7 +273,7 @@ impl StreamableConv1d {
 
     pub fn reset_batch_idx(&mut self, batch_idx: usize, _batch_size: usize) -> Result<()> {
         if let Some(v) = self.state_prev_xs.as_option() {
-            let v = v.contiguous()?;
+            let v = if v.is_contiguous() { v.clone() } else { v.contiguous()? };
             v.i(batch_idx..(1 + batch_idx))?.zero_set()?;
             self.state_prev_xs = StreamTensor::from_tensor(v);
         }
@@ -414,7 +414,7 @@ impl StreamableConvTranspose1d {
 
     pub fn reset_batch_idx(&mut self, batch_idx: usize, _batch_size: usize) -> Result<()> {
         if let Some(v) = self.state_prev_ys.as_option() {
-            let v = v.contiguous()?;
+            let v = if v.is_contiguous() { v.clone() } else { v.contiguous()? };
             v.i(batch_idx..(1 + batch_idx))?.zero_set()?;
             self.state_prev_ys = v.into();
         }

--- a/server/rust/moshi/moshi-core/src/kv_cache.rs
+++ b/server/rust/moshi/moshi-core/src/kv_cache.rs
@@ -170,8 +170,8 @@ impl ScatteredCacheBuilder {
         let mut cache_indices = Vec::with_capacity(b * seq_len);
         for (batch_i, &active) in batch_mask.iter().enumerate() {
             if !active {
-                attention_masks.extend(std::iter::repeat(0.0).take(seq_len * context));
-                cache_indices.extend(std::iter::repeat(self.indices[batch_i] as u32).take(seq_len));
+                attention_masks.extend(std::iter::repeat_n(0.0, seq_len * context));
+                cache_indices.extend(std::iter::repeat_n(self.indices[batch_i] as u32, seq_len));
             } else {
                 let start_index = self.indices[batch_i];
                 let start_pos = self.positions[batch_i];

--- a/server/rust/moshi/moshi-core/src/lm.rs
+++ b/server/rust/moshi/moshi-core/src/lm.rs
@@ -511,6 +511,7 @@ struct DepFormerSlice {
 }
 
 impl DepFormerSlice {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         idx: usize,
         num_slices: usize,
@@ -529,8 +530,6 @@ impl DepFormerSlice {
             vb.pp("depformer")
         } else if vb.contains_key("layers.0.norm1.alpha") {
             vb.clone()
-        } else if vb.contains_key(&format!("{idx}.transformer.layers.0.norm1.alpha")) {
-            vb.pp(idx).pp("transformer")
         } else {
             vb.pp(idx).pp("transformer")
         };
@@ -549,7 +548,7 @@ impl DepFormerSlice {
             root_vb.pp("depformer_text_emb")
         } else if root_vb.contains_key(&format!("depformer_emb.{}.weight", idx.saturating_sub(1))) {
              root_vb.pp("depformer_emb").pp(idx.saturating_sub(1))
-        } else if vb.contains_key(&format!("emb.embeddings.weight")) {
+        } else if vb.contains_key("emb.embeddings.weight") {
             vb.pp("emb")
         } else {
             vb.pp(idx).pp("emb")

--- a/server/rust/moshi/moshi-core/src/lm_generate.rs
+++ b/server/rust/moshi/moshi-core/src/lm_generate.rs
@@ -120,7 +120,7 @@ impl State {
             };
             let t = match t {
                 None => None,
-                Some(t) => Some(Tensor::from_vec(vec![t; 1], (1, 1), dev)?),
+                Some(t) => Some(Tensor::from_slice(&[t], (1, 1), dev)?),
             };
             codes.push(t)
         }
@@ -137,7 +137,7 @@ impl State {
         };
         let text_token = match text_token {
             None => None,
-            Some(t) => Some(Tensor::from_vec(vec![t; 1], (1, 1), dev)?),
+            Some(t) => Some(Tensor::from_slice(&[t], (1, 1), dev)?),
         };
         let (text_logits, ys) =
             self.model.forward_cond(text_token, codes, conditions, &().into())?;

--- a/server/rust/moshi/moshi-core/src/streaming.rs
+++ b/server/rust/moshi/moshi-core/src/streaming.rs
@@ -264,12 +264,12 @@ impl StreamingBinOp {
 
     pub fn reset_batch_idx(&mut self, batch_idx: usize, _batch_size: usize) -> Result<()> {
         if let Some(v) = self.prev_lhs.as_option() {
-            let v = v.contiguous()?;
+            let v = if v.is_contiguous() { v.clone() } else { v.contiguous()? };
             v.i(batch_idx..(1 + batch_idx))?.zero_set()?;
             self.prev_lhs = StreamTensor::from_tensor(v);
         }
         if let Some(v) = self.prev_rhs.as_option() {
-            let v = v.contiguous()?;
+            let v = if v.is_contiguous() { v.clone() } else { v.contiguous()? };
             v.i(batch_idx..(1 + batch_idx))?.zero_set()?;
             self.prev_rhs = StreamTensor::from_tensor(v);
         }

--- a/server/rust/moshi/moshi-core/src/transformer.rs
+++ b/server/rust/moshi/moshi-core/src/transformer.rs
@@ -502,7 +502,7 @@ impl StreamingMultiheadAttention {
             let v = v.narrow(2, k_len - k_target_len, k_target_len)?;
             (k, v)
         } else {
-            (k.clone(), v.clone())
+            (k, v)
         };
 
         let xs = if (q.dtype() == DType::BF16 || q.dtype() == DType::F16)


### PR DESCRIPTION
## Summary
Performance optimizations for moshi-core focusing on:

- **Contiguity Checks** - Add `is_contiguous()` guards before calling `.contiguous()` to skip unnecessary GPU copies
- **Redundant Clones** - Remove unnecessary `.clone()` calls in transformer hot paths
- **Tensor Allocation** - Replace `Tensor::from_vec` with `from_slice` for single-element tensors
- **Code Quality** - Fix all clippy warnings (-D warnings clean)

## Changes
- `transformer.rs`: Remove redundant k/v clones in attention
- `batched_transformer.rs`: Same optimization
- `streaming.rs`: Add contiguity checks in StreamingModule
- `lm_generate.rs`: Optimize tensor allocation for token generation

Closes #132