### PR TITLE
feat: Moshi Optimizations and Cleanup

### DIFF
--- a/server/rust/moshi/moshi-core/src/conv.rs
+++ b/server/rust/moshi/moshi-core/src/conv.rs
@@ -273,7 +273,7 @@ impl StreamableConv1d {
 
     pub fn reset_batch_idx(&mut self, batch_idx: usize, _batch_size: usize) -> Result<()> {
         if let Some(v) = self.state_prev_xs.as_option() {
-            let v = if v.is_contiguous() { v.clone() } else { v.contiguous()? };
+            let v = v.contiguous()?;
             v.i(batch_idx..(1 + batch_idx))?.zero_set()?;
             self.state_prev_xs = StreamTensor::from_tensor(v);
         }
@@ -414,7 +414,7 @@ impl StreamableConvTranspose1d {
 
     pub fn reset_batch_idx(&mut self, batch_idx: usize, _batch_size: usize) -> Result<()> {
         if let Some(v) = self.state_prev_ys.as_option() {
-            let v = if v.is_contiguous() { v.clone() } else { v.contiguous()? };
+            let v = v.contiguous()?;
             v.i(batch_idx..(1 + batch_idx))?.zero_set()?;
             self.state_prev_ys = v.into();
         }

--- a/server/rust/moshi/moshi-core/src/streaming.rs
+++ b/server/rust/moshi/moshi-core/src/streaming.rs
@@ -264,12 +264,12 @@ impl StreamingBinOp {
 
     pub fn reset_batch_idx(&mut self, batch_idx: usize, _batch_size: usize) -> Result<()> {
         if let Some(v) = self.prev_lhs.as_option() {
-            let v = if v.is_contiguous() { v.clone() } else { v.contiguous()? };
+            let v = v.contiguous()?;
             v.i(batch_idx..(1 + batch_idx))?.zero_set()?;
             self.prev_lhs = StreamTensor::from_tensor(v);
         }
         if let Some(v) = self.prev_rhs.as_option() {
-            let v = if v.is_contiguous() { v.clone() } else { v.contiguous()? };
+            let v = v.contiguous()?;
             v.i(batch_idx..(1 + batch_idx))?.zero_set()?;
             self.prev_rhs = StreamTensor::from_tensor(v);
         }

--- a/server/rust/moshi/moshi-server/src/bin/bench_perf.rs
+++ b/server/rust/moshi/moshi-server/src/bin/bench_perf.rs
@@ -110,6 +110,25 @@ pub struct BenchmarkResult {
     pub throughput_unit: Option<String>,
 }
 
+impl From<moshi_server::bench::LatencyStats> for BenchmarkResult {
+    fn from(stats: moshi_server::bench::LatencyStats) -> Self {
+        Self {
+            name: stats.name.to_string(),
+            iterations: stats.count as usize,
+            warmup_iterations: 0, // Not tracked in LatencyStats
+            total_duration_ms: stats.mean.as_secs_f64() * 1000.0 * stats.count as f64,
+            mean_ms: stats.mean.as_secs_f64() * 1000.0,
+            min_ms: stats.min.as_secs_f64() * 1000.0,
+            max_ms: stats.max.as_secs_f64() * 1000.0,
+            p50_ms: stats.p50.as_secs_f64() * 1000.0,
+            p95_ms: stats.p95.as_secs_f64() * 1000.0,
+            p99_ms: stats.p99.as_secs_f64() * 1000.0,
+            throughput: None,
+            throughput_unit: None,
+        }
+    }
+}
+
 /// Full benchmark suite results
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BenchmarkSuiteResults {
@@ -526,6 +545,8 @@ fn main() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use moshi_server::bench::LatencyRecorder;
+    use std::time::Duration;
 
     #[test]
     fn test_benchmark_result_from_stats() {


### PR DESCRIPTION
# Moshi Optimizations Walkthrough

This walkthrough details the optimizations and cleanups applied to the Moshi codebase. The focus was on removing redundant operations and verifying the integrity of existing optimizations.

## Changes

### Redundant Optimization Removal

We identified and removed unnecessary `contiguous()` checks in the streaming primitives. These checks were redundant because `contiguous()` already performs a check internally and returns the tensor as-is if it is already contiguous, without cloning.

#### [streaming.rs](file:///home/grant/delayed-streams-modeling/server/rust/moshi/moshi-core/src/streaming.rs)
- Simplified `reset_batch_idx` in `StreamingBinOp` to directly call `contiguous()?` instead of manually checking `is_contiguous()` and cloning.

#### [conv.rs](file:///home/grant/delayed-streams-modeling/server/rust/moshi/moshi-core/src/conv.rs)
- Simplified `reset_batch_idx` in `StreamableConv1d` and `StreamableConvTranspose1d` to directly call `contiguous()?`.

### Test Fixes

We also fixed compilation errors in the `moshi-server` benchmarking suite found during verification.

#### [bench_perf.rs](file:///home/grant/delayed-streams-modeling/server/rust/moshi/moshi-server/src/bin/bench_perf.rs)
- Added missing imports for `LatencyRecorder` and `Duration`.
- Implemented `From<LatencyStats> for BenchmarkResult` to allow seamless conversion of stats in tests.

## Verification Results

### Automated Tests
Ran the full test suite for both `moshi-core` and `moshi-server`.
- `cargo test -p moshi`: Passed.
- `cargo test -p moshi-server`: Passed (after fixing `bench_perf.rs`).

### Performance Verification
The changes are primarily code cleanups that remove redundant branching. The core performance characteristics remain preserved, and the removal of manual cloning in favor of `contiguous()` (which is a no-op for contiguous tensors) ensures efficient memory usage.
